### PR TITLE
纠正fekit alias中导致 webpack中模块路径解析错误的写法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+.idea

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@
  
 pack, sync命令
 + npm run pack，执行webpack打包，同时生成refs文件夹（vm，scripts，styles，ver文件）
-+ npm run sync，将pack生成的refs文件推到开发机
++ npm run sync， 同步当前工程目录信息到.dev 文件配置的开发机中的路径
 + npm run pack-sync，简化命令，执行pack && sync

--- a/bin/qwebpack-convert.js
+++ b/bin/qwebpack-convert.js
@@ -84,6 +84,12 @@ if(!fekitConfig) {
 exports = fekitConfig.json.export;
 alias = fekitConfig.json.alias;
 
+//fekit alias中 以/开头的路径，在webpack中会被当做绝对路径 导致模块解析错误
+Object.keys(alias).forEach(function(item,index){
+	alias[item] = alias[item].replace(/^(\/|\\)+/,'')
+});
+
+
 var template = filesys.readFileSync(webpackConfigPath, {
 	encoding: 'utf-8'
 });

--- a/package.json
+++ b/package.json
@@ -25,9 +25,12 @@
   "bugs": {
     "url": "https://github.com/sdwangbaotong/qwebpack-convert/issues"
   },
-  "maintainers": [{
-    "name": "baotong.wang",
-    "email": "sdwangbaotong@hotmail.com"
-  }],
-  "homepage": "https://github.com/sdwangbaotong/qwebpack-convert"
+  "maintainers": [
+    {
+      "name": "baotong.wang",
+      "email": "sdwangbaotong@hotmail.com"
+    }
+  ],
+  "homepage": "https://github.com/sdwangbaotong/qwebpack-convert",
+  "dependencies": {}
 }

--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -17,7 +17,7 @@ exports.forEach(function(output) {
 
     var key = output.replace(extensionPattern, '');
 
-    webpackExport[key] = rootPrefix + output;
+    webpackExport[key] = [rootPrefix + output];
 });
 
 // 生成ref文件夹，其中包括vm、ver文件


### PR DESCRIPTION
同步当前工程目录信息到.dev 文件配置的开发机中的路径
